### PR TITLE
Pin ag-grid-community and ag-grid-vue3 to exact versions

### DIFF
--- a/src/components/package.json
+++ b/src/components/package.json
@@ -50,7 +50,8 @@
   "dependencies": {
     "@types/d3-scale": "^4.0.9",
     "@types/d3-scale-chromatic": "^3.1.0",
-    "ag-grid-vue3": "^33.2.4",
+    "ag-grid-community": "33.2.4",
+    "ag-grid-vue3": "33.2.4",
     "arquero": "^8.0.1",
     "d3-scale": "^4.0.2",
     "d3-scale-chromatic": "^3.1.0",
@@ -63,7 +64,8 @@
   "peerDependencies": {
     "vue": "^3.4.18",
     "pinia": "^3.0.1",
-    "react": "^18.0.0 || ^19.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "ag-grid-community": "33.2.4"
   },
   "peerDependenciesMeta": {
     "vue": {


### PR DESCRIPTION
The CE and React bundles inline ag-grid-vue3's source, which imports private symbols (_ALL_GRID_OPTIONS, _ALL_EVENTS, etc.) from ag-grid-community by name. Those exports were renamed in ag-grid-community 33.3.0, so a consumer installing udi-toolkit lets ^33.2.4 float to 33.3.x and the bundled imports miss.

Pin both packages to 33.2.4 and declare ag-grid-community as a direct dep (plus peerDependency) so the resolver installs the version the bundle was built against.