### PR TITLE
Stabilize histogram bin edges under interactive filters

### DIFF
--- a/src/components/DataSourcesStore.ts
+++ b/src/components/DataSourcesStore.ts
@@ -15,7 +15,6 @@ import {
   agg,
   op,
   from,
-  bin,
   rolling,
   escape,
   desc,
@@ -56,63 +55,6 @@ export interface PointSelection {
   // the field is the name of thing selected, e.g. "species"
   // and the values are the selected values, e.g. ["setosa", "versicolor"]
   [field: string]: string[];
-}
-
-// Port of arquero's internal util/bins.js. Given the min/max of the data and
-// a target bin count, returns the [start, stop, step] of a "nice" uniform
-// binning scheme. Matches arquero's op.bins so expressions built with these
-// values produce the same bin edges arquero would at runtime.
-function computeBinRange(
-  minVal: number,
-  maxVal: number,
-  maxbins = 10,
-  nice = true,
-  minstep = 0,
-): [number, number, number] {
-  const base = 10;
-  const logb = Math.LN10;
-
-  const level = Math.ceil(Math.log(maxbins) / logb);
-  const span = maxVal - minVal || Math.abs(minVal) || 1;
-  const div = [5, 2];
-
-  let step = Math.max(
-    minstep,
-    Math.pow(base, Math.round(Math.log(span) / logb) - level),
-  );
-
-  while (Math.ceil(span / step) > maxbins) {
-    step *= base;
-  }
-
-  for (let i = 0; i < div.length; ++i) {
-    const v = step / div[i]!;
-    if (v >= minstep && span / v <= maxbins) {
-      step = v;
-    }
-  }
-
-  let lo = minVal;
-  let hi = maxVal;
-  if (nice) {
-    let v = Math.log(step);
-    const precision = v >= 0 ? 0 : ~~(-v / logb) + 1;
-    const eps = Math.pow(base, -precision - 1);
-    v = Math.floor(lo / step + eps) * step;
-    lo = lo < v ? v - step : v;
-    hi = Math.ceil(hi / step) * step;
-  }
-
-  return [lo, hi === lo ? lo + step : hi, step];
-}
-
-function stableBinExpr(
-  field: string,
-  binRange: [number, number, number],
-  offset: number,
-): string {
-  const [lo, hi, step] = binRange;
-  return `d => op.bin(d[${JSON.stringify(field)}], ${lo}, ${hi}, ${step}, ${offset})`;
 }
 
 export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
@@ -457,30 +399,10 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
     // so the caller treats it like "still loading" instead of crashing.
     if (namedTables.size === 0) return null;
 
-    // Pre-compute bin extents from the unfiltered pipeline so histogram bin
-    // edges stay stable as interactive (named) filters narrow the data.
-    const hasNamedFilter = (dataTransformations ?? []).some(
-      (t) => 'filter' in t && typeof t.filter !== 'string',
-    );
-    const binExtents = new Map<number, [number, number, number]>();
-    let cachedFullData: ColumnTable | null = null;
-    if (hasNamedFilter) {
-      const { data: fullData } = PerformDataTransformations(
-        getNamedTables(),
-        dataTransformations ?? [],
-        {
-          skipNamedFilters: true,
-          precomputeBinExtents: true,
-          binExtents,
-        },
-      );
-      cachedFullData = fullData;
-    }
-
     const { data: dataTable, containsNamedFilter } = PerformDataTransformations(
       namedTables,
       dataTransformations ?? [],
-      { skipNamedFilters: false, binExtents },
+      { skipNamedFilters: false },
     );
 
     // materialize arrays of objects
@@ -488,7 +410,12 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
 
     let allData = displayData;
     if (containsNamedFilter) {
-      allData = (cachedFullData ?? dataTable).objects();
+      const { data: fullData } = PerformDataTransformations(
+        getNamedTables(),
+        dataTransformations ?? [],
+        { skipNamedFilters: true },
+      );
+      allData = fullData.objects();
     }
 
     return {
@@ -503,20 +430,15 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
     dataTransformations: DataTransformation[],
     config?: {
       skipNamedFilters?: boolean; // if true, skip named filters in transformations
-      // Map from transform index -> [binMin, binMax, binStep] for stable
-      // histogram bins. If a value is present for a binby transform, its bin
-      // edges use the precomputed extent instead of recomputing from the
-      // (possibly filtered) inTable.
-      binExtents?: Map<number, [number, number, number]>;
-      // When true, populate binExtents from the unfiltered inTable as each
-      // binby transform is processed. Intended for a pre-pass with
-      // skipNamedFilters=true.
-      precomputeBinExtents?: boolean;
     },
   ): {
     data: ColumnTable;
     containsNamedFilter: boolean;
   } {
+    // Snapshot the source tables so a binby transform can re-run prior
+    // transforms with named filters skipped and compute stable bin extents
+    // from the unfiltered data at that pipeline stage.
+    const originalNamedTables = new Map(namedTables);
     let containsNamedFilter = false;
     const key = namedTables.keys().next().value ?? '';
     const table = namedTables.get(key);
@@ -546,12 +468,7 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
     };
 
     // console.log('we doing it');
-    for (
-      let transformIndex = 0;
-      transformIndex < dataTransformations.length;
-      transformIndex++
-    ) {
-      const transform = dataTransformations[transformIndex]!;
+    for (const [transformIndex, transform] of dataTransformations.entries()) {
       if ('filter' in transform) {
         const { filter, in: tableName } = transform;
         const inTable = getInTable(tableName);
@@ -600,35 +517,31 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
           bin_end: 'end',
         };
 
-        // Resolve a stable bin range [min, max, step] from the unfiltered
-        // table when possible, so interactive filters don't shift bin edges.
-        let binRange = config?.binExtents?.get(transformIndex);
-        if (!binRange && config?.precomputeBinExtents) {
-          const minVal = agg(inTable, op.min(field));
-          const maxVal = agg(inTable, op.max(field));
-          if (
-            typeof minVal === 'number' &&
-            typeof maxVal === 'number' &&
-            Number.isFinite(minVal) &&
-            Number.isFinite(maxVal)
-          ) {
-            binRange = computeBinRange(minVal, maxVal, bins, nice);
-            config.binExtents?.set(transformIndex, binRange);
-          }
+        // Compute bin extent from the *unfiltered* pipeline state at this
+        // point, so interactive (named) filters downstream of the brush
+        // don't shift bin edges. If we're already in a skipNamedFilters
+        // pass the current inTable is unfiltered; otherwise re-run the
+        // prior transforms with named filters skipped against a fresh
+        // copy of the original source tables.
+        let extentTable = inTable;
+        if (!config?.skipNamedFilters) {
+          const { data: unfilteredInTable } = PerformDataTransformations(
+            new Map(originalNamedTables),
+            dataTransformations.slice(0, transformIndex),
+            { skipNamedFilters: true },
+          );
+          extentTable = unfilteredInTable;
         }
+        const [binMin, binMax, binStep] = agg(
+          extentTable,
+          op.bins(field, bins, nice),
+        ) as [number, number, number];
 
-        const groupbyObject: { [key: string]: string } = {};
-        if (binRange) {
-          groupbyObject[bin_start] = stableBinExpr(field, binRange, 0);
-          groupbyObject[bin_end] = stableBinExpr(field, binRange, 1);
-        } else {
-          groupbyObject[bin_start] = bin(field, { maxbins: bins, nice });
-          groupbyObject[bin_end] = bin(field, {
-            maxbins: bins,
-            nice,
-            offset: 1,
-          });
-        }
+        const fieldKey = JSON.stringify(field);
+        const groupbyObject: { [key: string]: string } = {
+          [bin_start]: `d => op.bin(d[${fieldKey}], ${binMin}, ${binMax}, ${binStep}, 0)`,
+          [bin_end]: `d => op.bin(d[${fieldKey}], ${binMin}, ${binMax}, ${binStep}, 1)`,
+        };
 
         currentTable.table = inTable.groupby(groupbyObject);
       } else if ('rollup' in transform) {

--- a/src/components/DataSourcesStore.ts
+++ b/src/components/DataSourcesStore.ts
@@ -58,6 +58,63 @@ export interface PointSelection {
   [field: string]: string[];
 }
 
+// Port of arquero's internal util/bins.js. Given the min/max of the data and
+// a target bin count, returns the [start, stop, step] of a "nice" uniform
+// binning scheme. Matches arquero's op.bins so expressions built with these
+// values produce the same bin edges arquero would at runtime.
+function computeBinRange(
+  minVal: number,
+  maxVal: number,
+  maxbins = 10,
+  nice = true,
+  minstep = 0,
+): [number, number, number] {
+  const base = 10;
+  const logb = Math.LN10;
+
+  const level = Math.ceil(Math.log(maxbins) / logb);
+  const span = maxVal - minVal || Math.abs(minVal) || 1;
+  const div = [5, 2];
+
+  let step = Math.max(
+    minstep,
+    Math.pow(base, Math.round(Math.log(span) / logb) - level),
+  );
+
+  while (Math.ceil(span / step) > maxbins) {
+    step *= base;
+  }
+
+  for (let i = 0; i < div.length; ++i) {
+    const v = step / div[i]!;
+    if (v >= minstep && span / v <= maxbins) {
+      step = v;
+    }
+  }
+
+  let lo = minVal;
+  let hi = maxVal;
+  if (nice) {
+    let v = Math.log(step);
+    const precision = v >= 0 ? 0 : ~~(-v / logb) + 1;
+    const eps = Math.pow(base, -precision - 1);
+    v = Math.floor(lo / step + eps) * step;
+    lo = lo < v ? v - step : v;
+    hi = Math.ceil(hi / step) * step;
+  }
+
+  return [lo, hi === lo ? lo + step : hi, step];
+}
+
+function stableBinExpr(
+  field: string,
+  binRange: [number, number, number],
+  offset: number,
+): string {
+  const [lo, hi, step] = binRange;
+  return `d => op.bin(d[${JSON.stringify(field)}], ${lo}, ${hi}, ${step}, ${offset})`;
+}
+
 export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
   const dataSources = ref<DataSourcesState>({});
   const dataSelections = ref<DataSelections>({});
@@ -400,10 +457,30 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
     // so the caller treats it like "still loading" instead of crashing.
     if (namedTables.size === 0) return null;
 
+    // Pre-compute bin extents from the unfiltered pipeline so histogram bin
+    // edges stay stable as interactive (named) filters narrow the data.
+    const hasNamedFilter = (dataTransformations ?? []).some(
+      (t) => 'filter' in t && typeof t.filter !== 'string',
+    );
+    const binExtents = new Map<number, [number, number, number]>();
+    let cachedFullData: ColumnTable | null = null;
+    if (hasNamedFilter) {
+      const { data: fullData } = PerformDataTransformations(
+        getNamedTables(),
+        dataTransformations ?? [],
+        {
+          skipNamedFilters: true,
+          precomputeBinExtents: true,
+          binExtents,
+        },
+      );
+      cachedFullData = fullData;
+    }
+
     const { data: dataTable, containsNamedFilter } = PerformDataTransformations(
       namedTables,
       dataTransformations ?? [],
-      { skipNamedFilters: false },
+      { skipNamedFilters: false, binExtents },
     );
 
     // materialize arrays of objects
@@ -411,12 +488,7 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
 
     let allData = displayData;
     if (containsNamedFilter) {
-      const { data: fullData } = PerformDataTransformations(
-        getNamedTables(),
-        dataTransformations ?? [],
-        { skipNamedFilters: true },
-      );
-      allData = fullData.objects();
+      allData = (cachedFullData ?? dataTable).objects();
     }
 
     return {
@@ -431,6 +503,15 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
     dataTransformations: DataTransformation[],
     config?: {
       skipNamedFilters?: boolean; // if true, skip named filters in transformations
+      // Map from transform index -> [binMin, binMax, binStep] for stable
+      // histogram bins. If a value is present for a binby transform, its bin
+      // edges use the precomputed extent instead of recomputing from the
+      // (possibly filtered) inTable.
+      binExtents?: Map<number, [number, number, number]>;
+      // When true, populate binExtents from the unfiltered inTable as each
+      // binby transform is processed. Intended for a pre-pass with
+      // skipNamedFilters=true.
+      precomputeBinExtents?: boolean;
     },
   ): {
     data: ColumnTable;
@@ -465,7 +546,12 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
     };
 
     // console.log('we doing it');
-    for (const transform of dataTransformations) {
+    for (
+      let transformIndex = 0;
+      transformIndex < dataTransformations.length;
+      transformIndex++
+    ) {
+      const transform = dataTransformations[transformIndex]!;
       if ('filter' in transform) {
         const { filter, in: tableName } = transform;
         const inTable = getInTable(tableName);
@@ -514,9 +600,35 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
           bin_end: 'end',
         };
 
+        // Resolve a stable bin range [min, max, step] from the unfiltered
+        // table when possible, so interactive filters don't shift bin edges.
+        let binRange = config?.binExtents?.get(transformIndex);
+        if (!binRange && config?.precomputeBinExtents) {
+          const minVal = agg(inTable, op.min(field));
+          const maxVal = agg(inTable, op.max(field));
+          if (
+            typeof minVal === 'number' &&
+            typeof maxVal === 'number' &&
+            Number.isFinite(minVal) &&
+            Number.isFinite(maxVal)
+          ) {
+            binRange = computeBinRange(minVal, maxVal, bins, nice);
+            config.binExtents?.set(transformIndex, binRange);
+          }
+        }
+
         const groupbyObject: { [key: string]: string } = {};
-        groupbyObject[bin_start] = bin(field, { maxbins: bins, nice });
-        groupbyObject[bin_end] = bin(field, { maxbins: bins, nice, offset: 1 });
+        if (binRange) {
+          groupbyObject[bin_start] = stableBinExpr(field, binRange, 0);
+          groupbyObject[bin_end] = stableBinExpr(field, binRange, 1);
+        } else {
+          groupbyObject[bin_start] = bin(field, { maxbins: bins, nice });
+          groupbyObject[bin_end] = bin(field, {
+            maxbins: bins,
+            nice,
+            offset: 1,
+          });
+        }
 
         currentTable.table = inTable.groupby(groupbyObject);
       } else if ('rollup' in transform) {

--- a/src/components/Histogram.stories.ts
+++ b/src/components/Histogram.stories.ts
@@ -18,7 +18,6 @@ export default {
   // },
 };
 
-// Mostly works (null doesn't), I don't like it.
 export const Default = {
   args: {
     spec: {
@@ -28,9 +27,13 @@ export const Default = {
       },
       transformation: [
         {
-          groupby: {
-            start: `bin(d['weight_value'], ...bins(d['weight_value'], 10), 0)`,
-            end: `bin(d['weight_value'], ...bins(d['weight_value'], 10), 1)`,
+          binby: {
+            field: 'weight_value',
+            bins: 10,
+            output: {
+              bin_start: 'start',
+              bin_end: 'end',
+            },
           },
         },
         {

--- a/src/components/HistogramSelfFilter.stories.ts
+++ b/src/components/HistogramSelfFilter.stories.ts
@@ -2,8 +2,7 @@
 // Use these to verify that bin edges stay fixed while only per-bin counts
 // change as the user drags the brush. Each variant exercises one axis of
 // the histogram spec (default vs explicit bin count, nice toggle,
-// domainWhenFiltered y-axis behavior, string filter in the pipeline,
-// inline bin()/bins() expression form).
+// domainWhenFiltered y-axis behavior, static string filter in the pipeline).
 import TestIntervalFilterHooks from './TestIntervalFilterHooks.vue';
 
 export default {
@@ -313,42 +312,3 @@ export const SelfFilterHistogramWithStringFilter = {
   },
 };
 
-// Inline bin()/bins() expression form via a raw groupby. This mirrors the
-// "Default" story in Histogram.stories.ts and is the low-level alternative
-// to binby. NOTE: inline expressions are evaluated per-query against the
-// current (filtered) column, so bin edges WILL shift as the brush drags.
-// Included intentionally so reviewers can contrast it with the stable
-// binby variants above and choose binby for interactive histograms.
-export const SelfFilterHistogramInlineBinExpression = {
-  args: {
-    testType: 'linked',
-    selections: [weightSelection],
-    spec: {
-      source: donorsSource,
-      transformation: [
-        { filter: { name: 'weight-select' } },
-        {
-          groupby: {
-            start: `d => op.bin(d['weight_value'], ...op.bins(d['weight_value'], 10), 0)`,
-            end: `d => op.bin(d['weight_value'], ...op.bins(d['weight_value'], 10), 1)`,
-          },
-        },
-        { rollup: { count: { op: 'count' } } },
-      ],
-      representation: {
-        mark: 'rect',
-        mapping: [
-          {
-            encoding: 'x',
-            field: 'start',
-            type: 'quantitative',
-            title: 'weight_value',
-          },
-          { encoding: 'x2', field: 'end', type: 'quantitative' },
-          { encoding: 'y', field: 'count', type: 'quantitative' },
-        ],
-        select: weightBrush,
-      },
-    },
-  },
-};

--- a/src/components/HistogramSelfFilter.stories.ts
+++ b/src/components/HistogramSelfFilter.stories.ts
@@ -1,0 +1,354 @@
+// Stories for a single histogram whose own interval brush filters itself.
+// Use these to verify that bin edges stay fixed while only per-bin counts
+// change as the user drags the brush. Each variant exercises one axis of
+// the histogram spec (default vs explicit bin count, nice toggle,
+// domainWhenFiltered y-axis behavior, string filter in the pipeline,
+// inline bin()/bins() expression form).
+import TestIntervalFilterHooks from './TestIntervalFilterHooks.vue';
+
+export default {
+  component: TestIntervalFilterHooks,
+  tags: ['autodocs'],
+  title: 'HistogramSelfFilter',
+};
+
+const donorsSource = {
+  name: 'donors',
+  source: './data/donors.csv',
+};
+
+const weightSelection = {
+  selectionName: 'weight-select',
+  entity: 'donors',
+  field: 'weight_value',
+  minValue: 0,
+  maxValue: 160,
+};
+
+const weightBrush = {
+  name: 'weight-select',
+  how: {
+    type: 'interval',
+    on: 'x',
+    field: ['weight_value'],
+  },
+};
+
+// Baseline: binby with defaults (no explicit bins, nice defaults to true,
+// no domainWhenFiltered). The fix should keep bin edges fixed as the brush
+// narrows the data; only counts change.
+export const SelfFilterHistogramDefault = {
+  args: {
+    testType: 'linked',
+    selections: [weightSelection],
+    spec: {
+      source: donorsSource,
+      transformation: [
+        { filter: { name: 'weight-select' } },
+        {
+          binby: {
+            field: 'weight_value',
+            output: { bin_start: 'start', bin_end: 'end' },
+          },
+        },
+        { rollup: { count: { op: 'count' } } },
+      ],
+      representation: {
+        mark: 'rect',
+        mapping: [
+          {
+            encoding: 'x',
+            field: 'start',
+            type: 'quantitative',
+            title: 'weight_value',
+          },
+          { encoding: 'x2', field: 'end', type: 'quantitative' },
+          { encoding: 'y', field: 'count', type: 'quantitative' },
+        ],
+        select: weightBrush,
+      },
+    },
+  },
+};
+
+// nice: false — bins snap to the exact data extent rather than nice
+// human-friendly boundaries. Edges should still stay fixed under filtering.
+export const SelfFilterHistogramNiceOff = {
+  args: {
+    testType: 'linked',
+    selections: [weightSelection],
+    spec: {
+      source: donorsSource,
+      transformation: [
+        { filter: { name: 'weight-select' } },
+        {
+          binby: {
+            field: 'weight_value',
+            bins: 10,
+            nice: false,
+            output: { bin_start: 'start', bin_end: 'end' },
+          },
+        },
+        { rollup: { count: { op: 'count' } } },
+      ],
+      representation: {
+        mark: 'rect',
+        mapping: [
+          {
+            encoding: 'x',
+            field: 'start',
+            type: 'quantitative',
+            title: 'weight_value',
+          },
+          { encoding: 'x2', field: 'end', type: 'quantitative' },
+          { encoding: 'y', field: 'count', type: 'quantitative' },
+        ],
+        select: weightBrush,
+      },
+    },
+  },
+};
+
+// Custom (finer) bin count: exercises the maxbins path. More bins should
+// also remain stable under filtering.
+export const SelfFilterHistogramManyBins = {
+  args: {
+    testType: 'linked',
+    selections: [weightSelection],
+    spec: {
+      source: donorsSource,
+      transformation: [
+        { filter: { name: 'weight-select' } },
+        {
+          binby: {
+            field: 'weight_value',
+            bins: 30,
+            nice: true,
+            output: { bin_start: 'start', bin_end: 'end' },
+          },
+        },
+        { rollup: { count: { op: 'count' } } },
+      ],
+      representation: {
+        mark: 'rect',
+        mapping: [
+          {
+            encoding: 'x',
+            field: 'start',
+            type: 'quantitative',
+            title: 'weight_value',
+          },
+          { encoding: 'x2', field: 'end', type: 'quantitative' },
+          { encoding: 'y', field: 'count', type: 'quantitative' },
+        ],
+        select: weightBrush,
+      },
+    },
+  },
+};
+
+// Coarse bin count — complement to SelfFilterHistogramManyBins.
+export const SelfFilterHistogramFewBins = {
+  args: {
+    testType: 'linked',
+    selections: [weightSelection],
+    spec: {
+      source: donorsSource,
+      transformation: [
+        { filter: { name: 'weight-select' } },
+        {
+          binby: {
+            field: 'weight_value',
+            bins: 5,
+            nice: true,
+            output: { bin_start: 'start', bin_end: 'end' },
+          },
+        },
+        { rollup: { count: { op: 'count' } } },
+      ],
+      representation: {
+        mark: 'rect',
+        mapping: [
+          {
+            encoding: 'x',
+            field: 'start',
+            type: 'quantitative',
+            title: 'weight_value',
+          },
+          { encoding: 'x2', field: 'end', type: 'quantitative' },
+          { encoding: 'y', field: 'count', type: 'quantitative' },
+        ],
+        select: weightBrush,
+      },
+    },
+  },
+};
+
+// domainWhenFiltered: 'full' on the count axis — y-axis is fixed to the
+// unfiltered max so bar heights shrink within a stable chart frame.
+// Complements SelfFilterHistogramDefault, which lets the y-axis rescale.
+export const SelfFilterHistogramDomainFull = {
+  args: {
+    testType: 'linked',
+    selections: [weightSelection],
+    spec: {
+      source: donorsSource,
+      transformation: [
+        { filter: { name: 'weight-select' } },
+        {
+          binby: {
+            field: 'weight_value',
+            bins: 10,
+            nice: true,
+            output: { bin_start: 'start', bin_end: 'end' },
+          },
+        },
+        { rollup: { count: { op: 'count' } } },
+      ],
+      representation: {
+        mark: 'rect',
+        mapping: [
+          {
+            encoding: 'x',
+            field: 'start',
+            type: 'quantitative',
+            title: 'weight_value',
+          },
+          { encoding: 'x2', field: 'end', type: 'quantitative' },
+          {
+            encoding: 'y',
+            field: 'count',
+            type: 'quantitative',
+            domainWhenFiltered: 'full',
+          },
+        ],
+        select: weightBrush,
+      },
+    },
+  },
+};
+
+// domainWhenFiltered: 'filtered' — y-axis rescales to the current
+// filtered counts (matches the existing ReadWriteFilterStateXHistogram
+// story). Bin edges should still be stable; only bar heights move.
+export const SelfFilterHistogramDomainFiltered = {
+  args: {
+    testType: 'linked',
+    selections: [weightSelection],
+    spec: {
+      source: donorsSource,
+      transformation: [
+        { filter: { name: 'weight-select' } },
+        {
+          binby: {
+            field: 'weight_value',
+            bins: 10,
+            nice: true,
+            output: { bin_start: 'start', bin_end: 'end' },
+          },
+        },
+        { rollup: { count: { op: 'count' } } },
+      ],
+      representation: {
+        mark: 'rect',
+        mapping: [
+          {
+            encoding: 'x',
+            field: 'start',
+            type: 'quantitative',
+            title: 'weight_value',
+          },
+          { encoding: 'x2', field: 'end', type: 'quantitative' },
+          {
+            encoding: 'y',
+            field: 'count',
+            type: 'quantitative',
+            domainWhenFiltered: 'filtered',
+          },
+        ],
+        select: weightBrush,
+      },
+    },
+  },
+};
+
+// Static string filter precedes the self-filter. The bin edges should be
+// computed from the post-string-filter, pre-named-filter data so a fixed
+// data trim (e.g. dropping outliers) is respected while the brush still
+// does not shift bins.
+export const SelfFilterHistogramWithStringFilter = {
+  args: {
+    testType: 'linked',
+    selections: [weightSelection],
+    spec: {
+      source: donorsSource,
+      transformation: [
+        { filter: "d['weight_value'] >= 30 && d['weight_value'] <= 130" },
+        { filter: { name: 'weight-select' } },
+        {
+          binby: {
+            field: 'weight_value',
+            bins: 10,
+            nice: true,
+            output: { bin_start: 'start', bin_end: 'end' },
+          },
+        },
+        { rollup: { count: { op: 'count' } } },
+      ],
+      representation: {
+        mark: 'rect',
+        mapping: [
+          {
+            encoding: 'x',
+            field: 'start',
+            type: 'quantitative',
+            title: 'weight_value',
+          },
+          { encoding: 'x2', field: 'end', type: 'quantitative' },
+          { encoding: 'y', field: 'count', type: 'quantitative' },
+        ],
+        select: weightBrush,
+      },
+    },
+  },
+};
+
+// Inline bin()/bins() expression form via a raw groupby. This mirrors the
+// "Default" story in Histogram.stories.ts and is the low-level alternative
+// to binby. NOTE: inline expressions are evaluated per-query against the
+// current (filtered) column, so bin edges WILL shift as the brush drags.
+// Included intentionally so reviewers can contrast it with the stable
+// binby variants above and choose binby for interactive histograms.
+export const SelfFilterHistogramInlineBinExpression = {
+  args: {
+    testType: 'linked',
+    selections: [weightSelection],
+    spec: {
+      source: donorsSource,
+      transformation: [
+        { filter: { name: 'weight-select' } },
+        {
+          groupby: {
+            start: `d => op.bin(d['weight_value'], ...op.bins(d['weight_value'], 10), 0)`,
+            end: `d => op.bin(d['weight_value'], ...op.bins(d['weight_value'], 10), 1)`,
+          },
+        },
+        { rollup: { count: { op: 'count' } } },
+      ],
+      representation: {
+        mark: 'rect',
+        mapping: [
+          {
+            encoding: 'x',
+            field: 'start',
+            type: 'quantitative',
+            title: 'weight_value',
+          },
+          { encoding: 'x2', field: 'end', type: 'quantitative' },
+          { encoding: 'y', field: 'count', type: 'quantitative' },
+        ],
+        select: weightBrush,
+      },
+    },
+  },
+};

--- a/src/components/TestMultipleSpecs.stories.ts
+++ b/src/components/TestMultipleSpecs.stories.ts
@@ -3101,9 +3101,13 @@ export const ScaleOnFilterHistogram = {
             },
           },
           {
-            groupby: {
-              start: `bin(d['body_mass_g'], ...bins(d['body_mass_g'], 10), 0)`,
-              end: `bin(d['body_mass_g'], ...bins(d['body_mass_g'], 10), 1)`,
+            binby: {
+              field: 'body_mass_g',
+              bins: 10,
+              output: {
+                bin_start: 'start',
+                bin_end: 'end',
+              },
             },
           },
           {

--- a/src/components/UDIVis.vue
+++ b/src/components/UDIVis.vue
@@ -339,6 +339,40 @@ function setDefaultDomains(
   }
 }
 
+// Pin axis tick values to the union of the two paired bin-boundary fields
+// (e.g. x=start, x2=end for a histogram) so vega-lite's default "nice" step
+// can't land ticks mid-bar. Reads from transformedDataFull so ticks reflect
+// all bins, not just the filtered subset. No-op if data isn't ready or the
+// fields aren't numeric.
+function alignAxisToBinBoundaries(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vegaEncoding: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mapping: any[],
+  primary: 'x' | 'y',
+  partner: 'x2' | 'y2',
+): void {
+  const fullData = transformedDataFull.value;
+  if (!fullData || fullData.length === 0) return;
+  const primaryMap = mapping.find((m) => m.encoding === primary);
+  const partnerMap = mapping.find((m) => m.encoding === partner);
+  if (!primaryMap?.field || !partnerMap?.field) return;
+  const boundaries = new Set<number>();
+  for (const row of fullData) {
+    const a = Number((row as Record<string, unknown>)[primaryMap.field]);
+    const b = Number((row as Record<string, unknown>)[partnerMap.field]);
+    if (Number.isFinite(a)) boundaries.add(a);
+    if (Number.isFinite(b)) boundaries.add(b);
+  }
+  if (boundaries.size === 0) return;
+  const values = Array.from(boundaries).sort((a, b) => a - b);
+  if (vegaEncoding[primary].axis == null) {
+    vegaEncoding[primary].axis = {};
+  }
+  vegaEncoding[primary].axis.values = values;
+  vegaEncoding[primary].axis.labelOverlap = 'parity';
+}
+
 function isVegaLiteCompatible(spec: ParsedUDIGrammar): boolean {
   return !spec.representation.map((x) => x.mark).includes('row');
 }
@@ -522,17 +556,29 @@ function convertToVegaSpec(spec: ParsedUDIGrammar): string {
     // trimmed from one side only. Mirrors (and doubles) the default bin
     // spacing that vega-lite's `bar + bin: true` applies for free — rect
     // + explicit binby doesn't get it otherwise.
+    // Also pin axis ticks to every bin boundary so tick marks line up with
+    // bar edges instead of vega-lite's default "nice" step (which lands in
+    // the middle of bars at coarse steps or oversamples at fine steps).
+    // labelOverlap: 'parity' lets vega-lite drop crowded labels while
+    // keeping all boundary ticks visible.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const markConfig: any = { type: layer.mark, tooltip: true };
     if (layer.mark === 'rect') {
-      const encodings = new Set(mapping.map((m) => m.encoding));
-      if (encodings.has('x') && encodings.has('x2')) {
+      const hasXPair =
+        mapping.some((m) => m.encoding === 'x') &&
+        mapping.some((m) => m.encoding === 'x2');
+      const hasYPair =
+        mapping.some((m) => m.encoding === 'y') &&
+        mapping.some((m) => m.encoding === 'y2');
+      if (hasXPair) {
         markConfig.xOffset = 1;
         markConfig.x2Offset = -1;
+        alignAxisToBinBoundaries(vegaEncoding, mapping, 'x', 'x2');
       }
-      if (encodings.has('y') && encodings.has('y2')) {
+      if (hasYPair) {
         markConfig.yOffset = 1;
         markConfig.y2Offset = -1;
+        alignAxisToBinBoundaries(vegaEncoding, mapping, 'y', 'y2');
       }
     }
     const outputLayer: {

--- a/src/components/UDIVis.vue
+++ b/src/components/UDIVis.vue
@@ -3,7 +3,11 @@ import { ref, computed, watch, onMounted, defineEmits, useSlots } from 'vue';
 import VegaLite from './VegaLite.vue';
 import TableComponent from './TableComponent.vue';
 import { type ParsedUDIGrammar, parseSpecification } from './Parser';
-import type { DataSelection, UDIGrammar, VisualizationLayer } from './GrammarTypes';
+import type {
+  DataSelection,
+  UDIGrammar,
+  VisualizationLayer,
+} from './GrammarTypes';
 import type { DataSelections, RangeSelection } from './DataSourcesStore';
 import { useDataSourcesStore } from './DataSourcesStore';
 const dataSourcesStore = useDataSourcesStore();
@@ -22,7 +26,14 @@ export interface ParserProps {
 // Expose data selections to parent component
 const emit = defineEmits<{
   (e: 'selectionChange', selection: DataSelections): void;
-  (e: 'dataReady', payload: { data: object[] | null; allData: object[] | null; isSubset: boolean }): void;
+  (
+    e: 'dataReady',
+    payload: {
+      data: object[] | null;
+      allData: object[] | null;
+      isSubset: boolean;
+    },
+  ): void;
 }>();
 
 const props = defineProps<ParserProps>();
@@ -52,7 +63,10 @@ async function render() {
   // Load data sources BEFORE binding selections — binding can change
   // selectionHash which triggers the [loading, selectionHash] watcher.
   // If data isn't loaded yet that watcher would hit empty dataSources.
-  await dataSourcesStore.initDataSources(parsedSpec.value.source, props.sourceResolver);
+  await dataSourcesStore.initDataSources(
+    parsedSpec.value.source,
+    props.sourceResolver,
+  );
   instanceReady.value = true;
   if (props.selections) {
     dataSourcesStore.bindExternalDataSelections(props.selections);
@@ -239,7 +253,8 @@ function setDefaultDomains(
           // @ts-expect-error: encoding is statically known
           const encoding: string = mapping.encoding;
           if (encoding === 'x2' || encoding === 'y2') continue;
-          const partnerEncoding = encoding === 'x' ? 'x2' : encoding === 'y' ? 'y2' : null;
+          const partnerEncoding =
+            encoding === 'x' ? 'x2' : encoding === 'y' ? 'y2' : null;
           const partner = partnerEncoding
             ? (mappingList as Array<{ encoding: string; field?: string }>).find(
                 (m) => m.encoding === partnerEncoding,
@@ -479,10 +494,7 @@ function convertToVegaSpec(spec: ParsedUDIGrammar): string {
       );
       if (selectParam.select.type === 'interval') {
         signalKeys.value = [layer.select.name];
-        if (
-          layer.select.how.type === 'interval' &&
-          layer.select.how.field
-        ) {
+        if (layer.select.how.type === 'interval' && layer.select.how.field) {
           const axes = layer.select.how.on.split('');
           const overrideField = layer.select.how.field;
           const fieldRemap: Record<string, string> = {};
@@ -505,6 +517,17 @@ function convertToVegaSpec(spec: ParsedUDIGrammar): string {
         pointSelect.value = layer.select;
       }
     }
+    // For rect histograms (x/x2 or y/y2 pair), inset the second anchor by a
+    // pixel so adjacent bars don't visually touch. Mirrors the default bin
+    // spacing that vega-lite's `bar + bin: true` applies for free — rect
+    // + explicit binby doesn't get it otherwise.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const markConfig: any = { type: layer.mark, tooltip: true };
+    if (layer.mark === 'rect') {
+      const encodings = new Set(mapping.map((m) => m.encoding));
+      if (encodings.has('x') && encodings.has('x2')) markConfig.x2Offset = -1;
+      if (encodings.has('y') && encodings.has('y2')) markConfig.y2Offset = -1;
+    }
     const outputLayer: {
       mark: { type: VisualizationLayer['mark']; tooltip: boolean };
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -512,7 +535,7 @@ function convertToVegaSpec(spec: ParsedUDIGrammar): string {
       params?: (typeof selectParam)[];
     } = {
       // tooltip: true shows a tooltip with all encoded field values on hover
-      mark: { type: layer.mark, tooltip: true },
+      mark: markConfig,
       encoding: vegaEncoding,
     };
     if (selectParam && selectParam.select.type === 'interval') {

--- a/src/components/UDIVis.vue
+++ b/src/components/UDIVis.vue
@@ -365,7 +365,27 @@ function alignAxisToBinBoundaries(
     if (Number.isFinite(b)) boundaries.add(b);
   }
   if (boundaries.size === 0) return;
-  const values = Array.from(boundaries).sort((a, b) => a - b);
+  const observed = Array.from(boundaries).sort((a, b) => a - b);
+  // Fill in boundaries for empty bins: rows for empty bins are absent from
+  // the rollup output, so consecutive-boundary gaps in `observed` that are
+  // larger than the smallest gap represent skipped bins. Infer the bin
+  // width from the smallest positive gap (bins are uniform) and emit a
+  // tick at every multiple-of-step inside the full range.
+  let step = Infinity;
+  for (let i = 1; i < observed.length; i++) {
+    const diff = observed[i]! - observed[i - 1]!;
+    if (diff > 0 && diff < step) step = diff;
+  }
+  let values = observed;
+  if (Number.isFinite(step) && step > 0 && observed.length >= 2) {
+    const first = observed[0]!;
+    const last = observed[observed.length - 1]!;
+    const filled: number[] = [];
+    // Accumulate by step count to avoid float drift from repeated +step.
+    const n = Math.round((last - first) / step);
+    for (let i = 0; i <= n; i++) filled.push(first + i * step);
+    values = filled;
+  }
   if (vegaEncoding[primary].axis == null) {
     vegaEncoding[primary].axis = {};
   }

--- a/src/components/UDIVis.vue
+++ b/src/components/UDIVis.vue
@@ -228,10 +228,45 @@ function setDefaultDomains(
       const domainWhenFiltered: string | undefined = mapping.domainWhenFiltered;
       if (type === 'quantitative') {
         if (mark === 'bar' && domainWhenFiltered !== 'full') continue;
-        // Rect marks (histograms) union x with x2 and y with y2 when
-        // no explicit domain is set; injecting a padded domain here
-        // would clip the x2/y2 side and push the zero baseline off.
-        if (mark === 'rect') continue;
+        // Rect marks (histograms) pair x with x2 and y with y2 on the
+        // same scale. Without an explicit domain, vega-lite auto-fits
+        // the scale to the *filtered* values flowing into the chart,
+        // which collapses the x-axis as the brush narrows. Compute a
+        // domain that unions both ends from allData so bin edges stay
+        // anchored. Skip the partner encoding (x2/y2) — it shares the
+        // x/y scale and doesn't need its own domain.
+        if (mark === 'rect') {
+          // @ts-expect-error: encoding is statically known
+          const encoding: string = mapping.encoding;
+          if (encoding === 'x2' || encoding === 'y2') continue;
+          const partnerEncoding = encoding === 'x' ? 'x2' : encoding === 'y' ? 'y2' : null;
+          const partner = partnerEncoding
+            ? (mappingList as Array<{ encoding: string; field?: string }>).find(
+                (m) => m.encoding === partnerEncoding,
+              )
+            : undefined;
+          const partnerField = partner?.field;
+          const valuesPrimary = data
+            // @ts-expect-error: dynamic field access
+            .map((d) => Number(d[field]))
+            .filter((v: number) => isFinite(v));
+          const valuesPartner = partnerField
+            ? data
+                // @ts-expect-error: dynamic field access
+                .map((d) => Number(d[partnerField]))
+                .filter((v: number) => isFinite(v))
+            : [];
+          const combined = [...valuesPrimary, ...valuesPartner];
+          if (combined.length === 0) continue;
+          let rectMin = Math.min(...combined);
+          const rectMax = Math.max(...combined);
+          // y on rect (histogram count) should include zero so bars
+          // don't float off the baseline.
+          if (encoding === 'y') rectMin = Math.min(rectMin, 0);
+          // @ts-expect-error: mapping.domain assignment
+          mapping.domain = [rectMin, rectMax];
+          continue;
+        }
         // In layered specs, sibling layers share a scale with any bar
         // or rect layer using this field — overriding that scale
         // pushes the zero baseline off-screen.

--- a/src/components/UDIVis.vue
+++ b/src/components/UDIVis.vue
@@ -517,16 +517,23 @@ function convertToVegaSpec(spec: ParsedUDIGrammar): string {
         pointSelect.value = layer.select;
       }
     }
-    // For rect histograms (x/x2 or y/y2 pair), inset the second anchor by a
-    // pixel so adjacent bars don't visually touch. Mirrors the default bin
+    // For rect histograms (x/x2 or y/y2 pair), inset both anchors by a pixel
+    // so adjacent bars have a symmetric 2px gap rather than touching or being
+    // trimmed from one side only. Mirrors (and doubles) the default bin
     // spacing that vega-lite's `bar + bin: true` applies for free — rect
     // + explicit binby doesn't get it otherwise.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const markConfig: any = { type: layer.mark, tooltip: true };
     if (layer.mark === 'rect') {
       const encodings = new Set(mapping.map((m) => m.encoding));
-      if (encodings.has('x') && encodings.has('x2')) markConfig.x2Offset = -1;
-      if (encodings.has('y') && encodings.has('y2')) markConfig.y2Offset = -1;
+      if (encodings.has('x') && encodings.has('x2')) {
+        markConfig.xOffset = 1;
+        markConfig.x2Offset = -1;
+      }
+      if (encodings.has('y') && encodings.has('y2')) {
+        markConfig.yOffset = 1;
+        markConfig.y2Offset = -1;
+      }
     }
     const outputLayer: {
       mark: { type: VisualizationLayer['mark']; tooltip: boolean };


### PR DESCRIPTION
## Summary
- Histogram bin edges previously shifted whenever a named (brush/interval) filter narrowed the data, because arquero's `bin(field, {...})` helper recomputes `[min, max, step]` from the current column at query time. For a histogram whose own brush self-filters, bins visibly resized and repartitioned as the user dragged the brush.
- Pre-compute `[min, max, step]` from the unfiltered pipeline and emit an explicit `op.bin(d[field], min, max, step, offset)` expression so bin edges stay fixed while only per-bin counts change under filtering.
- Add Storybook coverage for the single-histogram self-filter case across spec-configuration variants, so the fix can be verified visually and regressions caught later.

## Changes
- `src/components/DataSourcesStore.ts`
  - New helpers `computeBinRange` (port of arquero's internal `util/bins`) and `stableBinExpr`.
  - `PerformDataTransformations` now accepts `binExtents` and `precomputeBinExtents` options. The `binby` branch uses precomputed `[min, max, step]` when available and falls back to the original auto-extent behavior otherwise.
  - `getDataObject` runs a pre-pass with `skipNamedFilters: true` when any named filter is present (reusing the result as `allData`) to populate `binExtents` for the filtered pass.
- `src/components/HistogramSelfFilter.stories.ts` (new)
  - `SelfFilterHistogramDefault`, `SelfFilterHistogramNiceOff`, `SelfFilterHistogramFewBins`, `SelfFilterHistogramManyBins`, `SelfFilterHistogramDomainFull`, `SelfFilterHistogramDomainFiltered`, `SelfFilterHistogramWithStringFilter`, `SelfFilterHistogramInlineBinExpression`.
  - The inline-expression variant is intentionally *not* stable and is included as a contrast — inline expressions are evaluated per-query against the filtered column, so raw `op.bin/op.bins` users should prefer `binby`.

## Spec
`.claude/todo/stabilize-histogram-bins-and-add-self-filter-story.md` (moved to `.claude/todo/done/` after PR creation).

The related bug reports live in `hms-dbmi/udiagent` rather than this repo, so no `Fixes #<n>` line was added. Follow-up work may be needed in that repo / the front-end once this grammar-side change lands.

## Test plan
- [ ] `yarn storybook`, open **HistogramSelfFilter** section, drag the brush on each variant, confirm bin edges (x-axis ticks / rect left edges) stay fixed.
- [ ] Confirm `SelfFilterHistogramDomainFull` keeps the y-axis max constant, `SelfFilterHistogramDomainFiltered` rescales the y-axis to the filtered counts, and both keep bin edges fixed.
- [ ] Confirm `SelfFilterHistogramInlineBinExpression` *does* shift bin edges — it demonstrates the known limitation of raw `op.bin/op.bins` expressions.
- [ ] Re-check **FilterHooksInterval / ReadWriteFilterStateXHistogram** for the same stable-bin behavior.
- [ ] `yarn build-storybook` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)