### PR TITLE
NickAkhmetov/Ensure vega tooltips are visible when components are embedded in high z-index container

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   "resolutions": {
     "flatted": "3.4.2",
     "node-forge": "1.4.0",
-    "path-to-regexp": "6.3.0",
     "**/anymatch/picomatch": "2.3.2",
     "**/readdirp/picomatch": "2.3.2",
     "**/micromatch/picomatch": "2.3.2",

--- a/src/components/VegaLite.vue
+++ b/src/components/VegaLite.vue
@@ -375,3 +375,12 @@ watch(() => props.selections, updateVegaChartSelections, { deep: true });
   color: red;
 }
 </style>
+
+<style>
+/* Ensure Vega tooltips render above containers with high z-index (e.g. MUI dialogs at 1300).
+   vega-tooltip portals the tooltip to <body> with a default z-index of 1000, which loses
+   to higher-z-index ancestors of the chart's mounting container. */
+#vg-tooltip-element {
+  z-index: 2147483647;
+}
+</style>

--- a/src/components/package.json
+++ b/src/components/package.json
@@ -123,7 +123,6 @@
   "resolutions": {
     "flatted": "3.4.2",
     "node-forge": "1.4.0",
-    "path-to-regexp": "6.3.0",
     "express": "4.21.2",
     "js-yaml": "4.1.1",
     "cross-spawn": "7.0.6",

--- a/src/components/yarn.lock
+++ b/src/components/yarn.lock
@@ -1540,9 +1540,9 @@ ag-grid-community@33.2.4:
   dependencies:
     ag-charts-types "11.2.4"
 
-ag-grid-vue3@^33.2.4:
+ag-grid-vue3@33.2.4:
   version "33.2.4"
-  resolved "https://registry.npmjs.org/ag-grid-vue3/-/ag-grid-vue3-33.2.4.tgz"
+  resolved "https://registry.yarnpkg.com/ag-grid-vue3/-/ag-grid-vue3-33.2.4.tgz#8e4af7765886b881042b7b52124e19f5ade656cf"
   integrity sha512-U5m4A9sc+jpoENwwl/AZ7r0053tbRvI39nRh55pYMJt6rrnotgUyJVHZfqJ6cExcSM3tqeW+vg1tMXGqoR4PNA==
   dependencies:
     ag-grid-community "33.2.4"
@@ -3884,10 +3884,10 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@0.1.12, path-to-regexp@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
-  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
+path-to-regexp@0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
+  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
 pathe@^2.0.1, pathe@^2.0.3:
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3939,10 +3939,10 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@0.1.12, path-to-regexp@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
-  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
+path-to-regexp@0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
+  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
 pathval@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
When the visualization is rendered in a container with a z-index > 1000, vega-lite's behavior of placing tooltips with `z-index: 1000` in a portal attached to the `body` of the document leads to the tooltips not being visible. This PR sets the tooltip index to 2^32-1 to avoid this issue.