### PR TITLE
NickAkhmetov/Migrate domain computations to UDI grammar/worker for single source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,87 @@ function App() {
 }
 ```
 
+### Headless data query (`queryData`)
+
+`queryData` runs a UDI Grammar spec through the same Arquero pipeline that
+`<UDIVis>` uses but returns the resulting rows instead of rendering a chart.
+Useful for filtered counts, exports, or any UI that needs the data but
+not the visualization. Results are memoized per
+`(sources, transformations, active selections)` tuple so repeat queries
+(e.g. brushing back to a previous range) serve from cache.
+
+```ts
+import { queryData } from 'udi-toolkit/react';
+
+const result = await queryData(
+  {
+    source: { name: 'donors', source: '/data/donors.csv' },
+    transformation: [{ rollup: { count: { op: 'count' } } }],
+  },
+  selections,
+  { displayDataOnly: true }, // skip materializing the full unfiltered table
+);
+// result?.displayData → [{ count: 1234 }]
+```
+
+`displayDataOnly: true` is a performance opt-in: when set, the second
+pipeline pass that materializes the unfiltered table for `allData` is
+skipped (and `allData` aliases `displayData`). Pass it for count/rollup
+queries that only read `displayData`.
+
+The function is also exported from `udi-toolkit/ce` for non-React
+consumers.
+
+### Pre-loading data and computing domains (`loadDataPackage`)
+
+`<UDIVis>` lazy-loads each CSV the first time a chart references it. If
+your app already knows the full set of datasets up front (e.g. a data
+package manifest), `loadDataPackage` fetches each URL once, parses it
+on the main thread (so the parsed table is cached for `<UDIVis>` to
+reuse — no re-fetch), and computes per-field domains in a dedicated
+Web Worker. Domains stream back per entity as they finish:
+
+```ts
+import { loadDataPackage } from 'udi-toolkit/react';
+import type { DataFieldDomain } from 'udi-toolkit/react';
+
+const allDomains: DataFieldDomain[] = [];
+
+await loadDataPackage(
+  [
+    { name: 'donors',   url: '/data/donors.csv'   },
+    { name: 'samples',  url: '/data/samples.csv'  },
+    { name: 'datasets', url: '/data/datasets.csv' },
+  ],
+  {
+    onEntityDomains: (entityName, domains) => {
+      allDomains.push(...domains);
+    },
+    onError: (entityName, message) => {
+      console.error(`Failed to load ${entityName}: ${message}`);
+    },
+  },
+);
+// At this point every <UDIVis> referencing one of these entities by
+// name will reuse the parsed table from the shared cache — no re-fetch.
+```
+
+Each `DataFieldDomain` has the shape:
+
+```ts
+interface DataFieldDomain {
+  entity: string;
+  field: string;
+  type: 'interval' | 'point';
+  domain: { min: number; max: number } | { values: string[] };
+  fieldDescription: string;
+}
+```
+
+`loadDataPackage` falls back to a main-thread compute path if Worker
+construction throws (e.g. restrictive CSP). The same function and
+types are exported from `udi-toolkit/ce` for non-React consumers.
+
 ### Building the library
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -232,10 +232,12 @@ const result = await queryData(
 // result?.displayData → [{ count: 1234 }]
 ```
 
-`displayDataOnly: true` is a performance opt-in: when set, the second
-pipeline pass that materializes the unfiltered table for `allData` is
-skipped (and `allData` aliases `displayData`). Pass it for count/rollup
-queries that only read `displayData`.
+`displayDataOnly` controls whether the result includes a materialized
+unfiltered `allData` table. When omitted, it defaults to `true` for
+specs whose transformation ends with a rollup (the unfiltered aggregate
+is rarely consumed) and `false` otherwise. For non-rollup specs that
+only read `displayData` (e.g. exports), set it to `true` explicitly to
+skip the expensive second pass.
 
 The function is also exported from `udi-toolkit/ce` for non-React
 consumers.
@@ -289,6 +291,48 @@ interface DataFieldDomain {
 `loadDataPackage` falls back to a main-thread compute path if Worker
 construction throws (e.g. restrictive CSP). The same function and
 types are exported from `udi-toolkit/ce` for non-React consumers.
+
+### Reacting to selections without re-rendering (`subscribeToSelections`)
+
+All selections — both Vega brushes (written directly by `<UDIVis>`'s
+signal handlers) and external filters bound via `queryData`'s
+`selections` argument — live in a single shared Pinia `DataSourcesStore`.
+Brush events fire at up to 60 Hz; mirroring them into a React store just
+to trigger an effect causes pointless re-renders. `subscribeToSelections`
+exposes the Pinia change feed directly:
+
+```ts
+import { subscribeToSelections, clearAllSelections } from 'udi-toolkit/react';
+
+useEffect(() => {
+  let unsubscribe: (() => void) | null = null;
+  let cancelled = false;
+  subscribeToSelections(() => {
+    // fires on every selection change — brush ticks AND programmatic updates
+    triggerMyQueryPump();
+  }).then((u) => {
+    if (cancelled) u();
+    else unsubscribe = u;
+  });
+  return () => {
+    cancelled = true;
+    unsubscribe?.();
+  };
+}, []);
+```
+
+The returned unsubscribe is wrapped in a promise because `ce-entry` (and
+the shared Pinia singleton) lazy-load on first udi-toolkit call; the
+callback fires synchronously once subscribed.
+
+`clearAllSelections()` wipes every active selection — useful for
+"reset session" flows so stale bookkeeping entries from closed
+visualizations don't accumulate across resets. Brushes themselves are
+already cleared by Vega when a chart unmounts.
+
+Both functions are also exported from `udi-toolkit/ce` for non-React
+consumers — they return a synchronous unsubscribe / `void` there since
+ce-entry is already imported.
 
 ### Building the library
 

--- a/src/components/DataSourcesStore.ts
+++ b/src/components/DataSourcesStore.ts
@@ -140,6 +140,18 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
     updateDataSelection(selectionName, null);
   }
 
+  /**
+   * Wipe every active selection. Used by consumers' "reset session"
+   * flows so stale entries from closed visualizations don't accumulate
+   * across resets. Bumps selectionHash exactly once so downstream
+   * watchers fire a single change notification.
+   */
+  function clearAllSelections(): void {
+    if (Object.keys(dataSelections.value).length === 0) return;
+    dataSelections.value = {};
+    selectionHash.value = '{}';
+  }
+
   function getDataSelection(
     selectionName: string,
   ): RangeSelection | PointSelection | null {
@@ -416,7 +428,17 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
   } | null {
     if (loading.value) return null;
 
-    const displayDataOnly = options?.displayDataOnly === true;
+    // Auto-default displayDataOnly=true when the transformation ends with
+    // a rollup. The second pipeline pass (skipNamedFilters: true) on a
+    // rollup spec produces a 1-row aggregate that callers rarely consume
+    // — the unfiltered total is usually available via cheaper channels
+    // (e.g. data package metadata). Explicit `displayDataOnly: false`
+    // still opts back in for callers that want the unfiltered rollup.
+    const transformations = dataTransformations ?? [];
+    const endsWithRollup =
+      transformations.length > 0 &&
+      'rollup' in (transformations[transformations.length - 1] as object);
+    const displayDataOnly = options?.displayDataOnly ?? endsWithRollup;
     const cacheKey = `${tablesVersion}|${selectionHash.value}|${displayDataOnly ? 'd' : 'a'}|${[...keys].sort().join('\0')}|${JSON.stringify(dataTransformations ?? null)}`;
     const cached = getDataObjectCache.get(cacheKey);
     if (cached) {
@@ -843,6 +865,7 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
     getDataSelection,
     updateDataSelection,
     clearDataSelection,
+    clearAllSelections,
     dataSelections,
     bindExternalDataSelections,
   };

--- a/src/components/DataSourcesStore.ts
+++ b/src/components/DataSourcesStore.ts
@@ -301,6 +301,10 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
 
   const loading = ref<boolean>(true);
   const selectionHash = ref<string>('');
+  /** Bumped whenever a source's parsed table is replaced, invalidating the
+   *  getDataObject memoization. Plain counter (not a Vue ref) since it's
+   *  only read inside getDataObject — no reactivity needed. */
+  let tablesVersion = 0;
 
   async function initDataSources(
     sources: DataSource[],
@@ -350,6 +354,7 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
       }
       const dest: ColumnTable = await loadCSV(dataSource.source, { delimiter });
       dataSources.value[dataSource.name] = { source: dataSource, dest };
+      tablesVersion++;
     })();
 
     pendingLoads.set(key, promise);
@@ -358,6 +363,21 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
     } finally {
       pendingLoads.delete(key);
     }
+  }
+
+  /**
+   * Install a pre-parsed table into the cache so later initDataSource()
+   * calls for the same (name, url) become no-ops. Used by loadDataPackage
+   * to avoid double-fetching CSVs that the caller already has in hand.
+   */
+  function seedDataSource(
+    name: string,
+    url: string,
+    table: ColumnTable,
+  ): void {
+    const source: DataSource = { name, source: url };
+    dataSources.value[name] = { source, dest: table };
+    tablesVersion++;
   }
 
   function getDataSource(key: string): DataInterface | null {
@@ -369,15 +389,42 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
     return dataSources.value[key] ?? null;
   }
 
+  // Memoizes getDataObject results across repeat queries with the same
+  // (sources, transformations, selections, table version) tuple. Live
+  // filter brushing fires the same query shape many times per second
+  // with only the selection payload changing; selectionHash is part of
+  // the key, so brand-new selections still recompute. The cap is small
+  // because the dominant access pattern is "user toggles between a
+  // handful of filter combinations," not "user explores 100s of unique
+  // filter states per second."
+  const MAX_CACHE_ENTRIES = 64;
+  type GetDataObjectResult = {
+    displayData: object[];
+    allData: object[];
+    isDisplayDataSubset: boolean;
+  };
+  const getDataObjectCache = new Map<string, GetDataObjectResult>();
+
   function getDataObject(
     keys: string[],
     dataTransformations?: DataTransformation[],
+    options?: { displayDataOnly?: boolean },
   ): {
     displayData: object[]; // only the data that should be displayed
     allData: object[]; // all data (needed for full domains)
     isDisplayDataSubset: boolean; // true if the returned data is a subset of the full data
   } | null {
     if (loading.value) return null;
+
+    const displayDataOnly = options?.displayDataOnly === true;
+    const cacheKey = `${tablesVersion}|${selectionHash.value}|${displayDataOnly ? 'd' : 'a'}|${[...keys].sort().join('\0')}|${JSON.stringify(dataTransformations ?? null)}`;
+    const cached = getDataObjectCache.get(cacheKey);
+    if (cached) {
+      // LRU-ish touch: re-insert to mark as most-recently-used.
+      getDataObjectCache.delete(cacheKey);
+      getDataObjectCache.set(cacheKey, cached);
+      return cached;
+    }
 
     // make copy of tables from data sources
     const getNamedTables = () => {
@@ -409,7 +456,7 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
     const displayData = dataTable.objects();
 
     let allData = displayData;
-    if (containsNamedFilter) {
+    if (containsNamedFilter && !displayDataOnly) {
       const { data: fullData } = PerformDataTransformations(
         getNamedTables(),
         dataTransformations ?? [],
@@ -418,11 +465,18 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
       allData = fullData.objects();
     }
 
-    return {
+    const result: GetDataObjectResult = {
       displayData,
       allData,
       isDisplayDataSubset: containsNamedFilter,
     };
+    getDataObjectCache.set(cacheKey, result);
+    if (getDataObjectCache.size > MAX_CACHE_ENTRIES) {
+      // Map iteration order is insertion order — drop the oldest.
+      const oldest = getDataObjectCache.keys().next().value;
+      if (oldest !== undefined) getDataObjectCache.delete(oldest);
+    }
+    return result;
   }
 
   function PerformDataTransformations(
@@ -783,6 +837,7 @@ export const useDataSourcesStore = defineStore('DataSourcesStore', () => {
     loading,
     selectionHash,
     initDataSources,
+    seedDataSource,
     getDataObject,
     watchDataSelection,
     getDataSelection,

--- a/src/components/UDIVis.vue
+++ b/src/components/UDIVis.vue
@@ -2,6 +2,14 @@
 import { ref, computed, watch, onMounted, defineEmits, useSlots } from 'vue';
 import VegaLite from './VegaLite.vue';
 import TableComponent from './TableComponent.vue';
+
+// The template root is a fragment (v-if/v-else templates), so Vue can't
+// auto-inherit `class`/`style`/etc. onto a single child. When mounted as
+// a custom element via defineCustomElement, those attributes already
+// live on the `<udi-vis>` host — CSS targeting works as expected. Opt
+// out of inheritance to silence the "extraneous non-props attributes"
+// warning.
+defineOptions({ inheritAttrs: false });
 import { type ParsedUDIGrammar, parseSpecification } from './Parser';
 import type {
   DataSelection,

--- a/src/components/ce-entry.ts
+++ b/src/components/ce-entry.ts
@@ -3,6 +3,16 @@ import { defineCustomElement } from 'vue';
 import UDIVisComp from './UDIVis.vue';
 import type { UDIGrammar, DataSource, DataTransformation } from './GrammarTypes';
 import { useDataSourcesStore, type DataSelections } from './DataSourcesStore';
+import {
+  loadDataPackage as loadDataPackageImpl,
+  type SourceSpec,
+  type LoadDataPackageOptions,
+} from './loadDataPackage';
+import type {
+  DataFieldDomain,
+  IntervalDomain,
+  CategoricalDomain,
+} from './domainTypes';
 
 // Shared Pinia instance for all <udi-vis> elements on the page.
 // This enables cross-chart filtering: all instances share the same
@@ -34,6 +44,16 @@ export interface QueryDataResult {
   isSubset: boolean;
 }
 
+export interface QueryDataOptions {
+  /** Maps entity names → canonical URLs, overriding URLs embedded in the spec. */
+  sourceResolver?: Record<string, string>;
+  /** Skip materializing the full unfiltered table for `allData`. When true,
+   *  `allData` shares its reference with `displayData`. Use this when the
+   *  caller only reads `displayData` (e.g. count chips, rollup queries) —
+   *  the second pipeline pass is the most expensive part of getDataObject. */
+  displayDataOnly?: boolean;
+}
+
 /**
  * Run a data query against the shared DataSourcesStore.
  *
@@ -42,18 +62,19 @@ export interface QueryDataResult {
  *
  * @param spec  A grammar-like object with `source` and optional `transformation`.
  * @param selections  Optional external selections to bind before querying.
+ * @param options  Optional per-call options (sourceResolver, displayDataOnly).
  * @returns The transformed data, or `null` if sources are still loading.
  */
 export async function queryData(
   spec: QueryDataSpec,
   selections?: DataSelections,
-  sourceResolver?: Record<string, string>,
+  options?: QueryDataOptions,
 ): Promise<QueryDataResult | null> {
   const store = useDataSourcesStore(pinia);
 
   const sources: DataSource[] = Array.isArray(spec.source) ? spec.source : [spec.source];
 
-  await store.initDataSources(sources, sourceResolver);
+  await store.initDataSources(sources, options?.sourceResolver);
 
   if (selections) {
     store.bindExternalDataSelections(selections);
@@ -62,6 +83,7 @@ export async function queryData(
   const result = store.getDataObject(
     sources.map((s) => s.name),
     spec.transformation,
+    { displayDataOnly: options?.displayDataOnly === true },
   );
 
   if (!result) return null;
@@ -73,5 +95,24 @@ export async function queryData(
   };
 }
 
+/**
+ * Fetch a set of CSVs exactly once, seed the shared DataSourcesStore so
+ * any <udi-vis> / queryData call reuses the parsed tables, and stream
+ * per-entity domains back via callbacks.
+ */
+export function loadDataPackage(
+  sources: SourceSpec[],
+  options?: LoadDataPackageOptions,
+): Promise<void> {
+  return loadDataPackageImpl(pinia, sources, options);
+}
+
 export { UDIVisElement };
 export type { UDIGrammar, DataSelections };
+export type {
+  SourceSpec,
+  LoadDataPackageOptions,
+  DataFieldDomain,
+  IntervalDomain,
+  CategoricalDomain,
+};

--- a/src/components/ce-entry.ts
+++ b/src/components/ce-entry.ts
@@ -1,5 +1,5 @@
 import { createPinia } from 'pinia';
-import { defineCustomElement } from 'vue';
+import { defineCustomElement, watch } from 'vue';
 import UDIVisComp from './UDIVis.vue';
 import type { UDIGrammar, DataSource, DataTransformation } from './GrammarTypes';
 import { useDataSourcesStore, type DataSelections } from './DataSourcesStore';
@@ -49,8 +49,12 @@ export interface QueryDataOptions {
   sourceResolver?: Record<string, string>;
   /** Skip materializing the full unfiltered table for `allData`. When true,
    *  `allData` shares its reference with `displayData`. Use this when the
-   *  caller only reads `displayData` (e.g. count chips, rollup queries) —
-   *  the second pipeline pass is the most expensive part of getDataObject. */
+   *  caller only reads `displayData` — the second pipeline pass is the
+   *  most expensive part of getDataObject for non-rollup specs.
+   *
+   *  When omitted, defaults to `true` if the transformation ends with a
+   *  rollup (the unfiltered aggregate is rarely consumed) and `false`
+   *  otherwise. Pass `false` explicitly to force the unfiltered pass. */
   displayDataOnly?: boolean;
 }
 
@@ -105,6 +109,34 @@ export function loadDataPackage(
   options?: LoadDataPackageOptions,
 ): Promise<void> {
   return loadDataPackageImpl(pinia, sources, options);
+}
+
+/**
+ * Fire `callback` whenever any selection in the shared DataSourcesStore
+ * changes — brushes from `<udi-vis>` signals, programmatic updates from
+ * queryData's `selections` binding, or `clearAllSelections()`.
+ *
+ * Returns an `unsubscribe` function. Use this when you want to react to
+ * brush state without subscribing to a mirror in your own framework's
+ * state store (avoids re-rendering on every 60Hz brush tick).
+ */
+export function subscribeToSelections(callback: () => void): () => void {
+  const store = useDataSourcesStore(pinia);
+  return watch(
+    () => store.selectionHash,
+    () => callback(),
+    { flush: 'sync' },
+  );
+}
+
+/**
+ * Clear every active selection. Intended for consumers' "reset session"
+ * flows; brush selections naturally clear via Vega when a chart unmounts,
+ * but this drops the bookkeeping entries so they don't accumulate.
+ */
+export function clearAllSelections(): void {
+  const store = useDataSourcesStore(pinia);
+  store.clearAllSelections();
 }
 
 export { UDIVisElement };

--- a/src/components/ce.d.ts
+++ b/src/components/ce.d.ts
@@ -40,6 +40,16 @@ export declare function loadDataPackage(
   options?: LoadDataPackageOptions,
 ): Promise<void>;
 
+/**
+ * Fire `callback` whenever any selection in the shared DataSourcesStore
+ * changes — brushes from <udi-vis> signals, programmatic bindings, or
+ * clearAllSelections(). Returns an unsubscribe function.
+ */
+export declare function subscribeToSelections(callback: () => void): () => void;
+
+/** Wipe every active selection in the shared DataSourcesStore. */
+export declare function clearAllSelections(): void;
+
 export type {
   UDIGrammar,
   DataSelections,

--- a/src/components/ce.d.ts
+++ b/src/components/ce.d.ts
@@ -1,5 +1,54 @@
 import type { UDIGrammar } from './dist/GrammarTypes';
 import type { DataSelections } from './dist/DataSourcesStore';
+import type {
+  QueryDataSpec,
+  QueryDataResult,
+  QueryDataOptions,
+} from './dist/ce-entry';
+import type {
+  SourceSpec,
+  LoadDataPackageOptions,
+} from './dist/loadDataPackage';
+import type {
+  DataFieldDomain,
+  IntervalDomain,
+  CategoricalDomain,
+} from './dist/domainTypes';
 
 export declare const UDIVisElement: CustomElementConstructor;
-export type { UDIGrammar, DataSelections };
+
+/**
+ * Headless data query against the shared DataSourcesStore. Loads any
+ * uncached sources, applies the transformation pipeline, and returns
+ * the result — no chart mounted.
+ */
+export declare function queryData(
+  spec: QueryDataSpec,
+  selections?: DataSelections,
+  options?: QueryDataOptions,
+): Promise<QueryDataResult | null>;
+
+/**
+ * Fetch each CSV exactly once, seed the shared DataSourcesStore (so
+ * subsequent <udi-vis> renders reuse the parsed table instead of
+ * re-fetching), and stream per-field domains back via callbacks. The
+ * domain computation runs in a Web Worker; falls back to the main
+ * thread if Worker construction throws.
+ */
+export declare function loadDataPackage(
+  sources: SourceSpec[],
+  options?: LoadDataPackageOptions,
+): Promise<void>;
+
+export type {
+  UDIGrammar,
+  DataSelections,
+  QueryDataSpec,
+  QueryDataResult,
+  QueryDataOptions,
+  SourceSpec,
+  LoadDataPackageOptions,
+  DataFieldDomain,
+  IntervalDomain,
+  CategoricalDomain,
+};

--- a/src/components/domain-worker.ts
+++ b/src/components/domain-worker.ts
@@ -1,0 +1,53 @@
+/**
+ * Web Worker entry: dispatches incoming compute requests to the pure
+ * domain-computation logic in domainCompute.ts and streams results back.
+ *
+ * Top-level `self` access means this module must only be loaded inside a
+ * worker context (via `?worker&inline`). The main-thread fallback path
+ * imports computeEntityDomains directly from domainCompute.ts instead.
+ *
+ * Message protocol:
+ *   Main → Worker:  ComputeDomainsRequest  (one message; batched resources)
+ *   Worker → Main:  EntityDomainsResult     (one per resource, streamed)
+ *   Worker → Main:  DoneResult | ErrorResult (termination)
+ */
+
+import { computeEntityDomains } from './domainCompute';
+import type {
+  WorkerMessage,
+  WorkerResponse,
+  EntityDomainsResult,
+  DoneResult,
+  ErrorResult,
+} from './domainTypes';
+
+const workerSelf = self as unknown as {
+  onmessage: ((event: MessageEvent<WorkerMessage>) => void) | null;
+  postMessage: (msg: WorkerResponse) => void;
+};
+
+workerSelf.onmessage = (event: MessageEvent<WorkerMessage>) => {
+  const msg = event.data;
+  if (msg.type !== 'compute') return;
+
+  for (const resource of msg.resources) {
+    try {
+      const domains = computeEntityDomains(resource);
+      const response: EntityDomainsResult = {
+        type: 'entity-domains',
+        entityName: resource.entityName,
+        domains,
+      };
+      workerSelf.postMessage(response);
+    } catch (e) {
+      const response: ErrorResult = {
+        type: 'error',
+        entityName: resource.entityName,
+        message: e instanceof Error ? e.message : String(e),
+      };
+      workerSelf.postMessage(response);
+    }
+  }
+
+  workerSelf.postMessage({ type: 'done' } satisfies DoneResult);
+};

--- a/src/components/domainCompute.ts
+++ b/src/components/domainCompute.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure domain-computation logic. Shared between the Web Worker (which
+ * runs it off the main thread) and the main-thread fallback path. No
+ * top-level side effects so it's safe to import from either context.
+ */
+
+import type { DataFieldDomain, EntityComputeInput } from './domainTypes';
+
+export function computeEntityDomains(
+  resource: EntityComputeInput,
+): DataFieldDomain[] {
+  const domains: DataFieldDomain[] = [];
+
+  for (const { name, values } of resource.columns) {
+    const isNumeric = values.every(
+      (v) => v == null || !isNaN(+(v as number)),
+    );
+
+    if (isNumeric) {
+      let min = Infinity;
+      let max = -Infinity;
+      for (const v of values) {
+        if (v == null) continue;
+        const n = +(v as number);
+        if (n < min) min = n;
+        if (n > max) max = n;
+      }
+      domains.push({
+        entity: resource.entityName,
+        field: name,
+        type: 'interval',
+        fieldDescription: resource.fieldDescriptions[name] ?? '',
+        domain: { min, max },
+      });
+    } else {
+      domains.push({
+        entity: resource.entityName,
+        field: name,
+        type: 'point',
+        fieldDescription: resource.fieldDescriptions[name] ?? '',
+        domain: { values: Array.from(new Set(values)) as string[] },
+      });
+    }
+  }
+
+  return domains;
+}

--- a/src/components/domainTypes.ts
+++ b/src/components/domainTypes.ts
@@ -1,0 +1,63 @@
+/**
+ * Public types for the loadDataPackage / domain-computation pipeline.
+ *
+ * These shapes are part of udi-toolkit's exported surface — consumers
+ * (udi-chat-react today) import DataFieldDomain etc. via udi-toolkit/react.
+ */
+
+export interface IntervalDomain {
+  min: number;
+  max: number;
+}
+
+export interface CategoricalDomain {
+  values: string[];
+}
+
+export interface DataFieldDomain {
+  entity: string;
+  field: string;
+  type: 'interval' | 'point';
+  domain: IntervalDomain | CategoricalDomain;
+  fieldDescription: string;
+}
+
+// ── Worker protocol (internal, but co-located so the worker and the
+//    orchestrator share one source of truth) ────────────────────────────
+
+/** One column's raw values, extracted on the main thread from Arquero. */
+export interface ColumnInput {
+  name: string;
+  values: unknown[];
+}
+
+/** Per-entity payload sent to the worker for domain computation. */
+export interface EntityComputeInput {
+  entityName: string;
+  fieldDescriptions: Record<string, string>;
+  columns: ColumnInput[];
+}
+
+export interface ComputeDomainsRequest {
+  type: 'compute';
+  resources: EntityComputeInput[];
+}
+
+export interface EntityDomainsResult {
+  type: 'entity-domains';
+  entityName: string;
+  domains: DataFieldDomain[];
+}
+
+export interface DoneResult {
+  type: 'done';
+}
+
+export interface ErrorResult {
+  type: 'error';
+  entityName: string;
+  message: string;
+}
+
+export type WorkerMessage = ComputeDomainsRequest;
+export type WorkerResponse = EntityDomainsResult | DoneResult | ErrorResult;

--- a/src/components/loadDataPackage.ts
+++ b/src/components/loadDataPackage.ts
@@ -1,0 +1,149 @@
+/// <reference types="vite/client" />
+
+/**
+ * Public API: loadDataPackage()
+ *
+ * Fetches each declared CSV exactly once, seeds the shared DataSourcesStore
+ * (so subsequent <udi-vis> / queryData calls reuse the parsed table), and
+ * runs per-column domain computation off the main thread in a Web Worker.
+ *
+ * The orchestrator is the single entry point for callers that want both
+ * data caching and domain summaries. UDIVis and queryData continue to
+ * lazy-load uncached sources on their own — this just primes the cache
+ * and surfaces domains.
+ */
+
+import type { Pinia } from 'pinia';
+import { fromCSV } from 'arquero';
+import DomainWorker from './domain-worker?worker&inline';
+import { useDataSourcesStore } from './DataSourcesStore';
+import { computeEntityDomains } from './domainCompute';
+import type {
+  DataFieldDomain,
+  EntityComputeInput,
+  WorkerResponse,
+} from './domainTypes';
+
+export interface SourceSpec {
+  /** Entity name, used as the DataSourcesStore key. */
+  name: string;
+  /** Resolved URL of the CSV/TSV file. */
+  url: string;
+  /** Override the delimiter; defaults to '\t' for .tsv URLs, ',' otherwise. */
+  delimiter?: string;
+  /** Optional per-field human descriptions, passed through into domains. */
+  fieldDescriptions?: Record<string, string>;
+}
+
+export interface LoadDataPackageOptions {
+  /** Forwarded to fetch() for each CSV request. */
+  fetchOptions?: RequestInit;
+  /** Called once per entity when its domains have been computed. */
+  onEntityDomains?: (entityName: string, domains: DataFieldDomain[]) => void;
+  /** Called when an individual source fails (others continue). */
+  onError?: (entityName: string, message: string) => void;
+}
+
+function inferDelimiter(spec: SourceSpec): string {
+  if (spec.delimiter) return spec.delimiter;
+  return spec.url.endsWith('.tsv') ? '\t' : ',';
+}
+
+/**
+ * Fetch + parse + seed + compute domains for a batch of sources.
+ * Resolves once all sources have been processed.
+ */
+export async function loadDataPackage(
+  pinia: Pinia,
+  sources: SourceSpec[],
+  options?: LoadDataPackageOptions,
+): Promise<void> {
+  const store = useDataSourcesStore(pinia);
+  const inputs: EntityComputeInput[] = [];
+
+  for (const spec of sources) {
+    try {
+      const response = await fetch(spec.url, options?.fetchOptions);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      }
+      const csvText = await response.text();
+      const delimiter = inferDelimiter(spec);
+      const table = fromCSV(csvText, { delimiter });
+
+      store.seedDataSource(spec.name, spec.url, table);
+
+      inputs.push({
+        entityName: spec.name,
+        fieldDescriptions: spec.fieldDescriptions ?? {},
+        columns: table
+          .columnNames()
+          .map((name) => ({ name, values: table.array(name) as unknown[] })),
+      });
+    } catch (e) {
+      options?.onError?.(
+        spec.name,
+        e instanceof Error ? e.message : String(e),
+      );
+    }
+  }
+
+  if (inputs.length === 0) return;
+
+  try {
+    await computeDomainsInWorker(inputs, options);
+  } catch {
+    computeDomainsMainThread(inputs, options);
+  }
+}
+
+function computeDomainsInWorker(
+  inputs: EntityComputeInput[],
+  options?: LoadDataPackageOptions,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let worker: Worker;
+    try {
+      worker = new DomainWorker();
+    } catch (e) {
+      reject(e instanceof Error ? e : new Error(String(e)));
+      return;
+    }
+
+    worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      const msg = event.data;
+      if (msg.type === 'entity-domains') {
+        options?.onEntityDomains?.(msg.entityName, msg.domains);
+      } else if (msg.type === 'error') {
+        options?.onError?.(msg.entityName, msg.message);
+      } else if (msg.type === 'done') {
+        worker.terminate();
+        resolve();
+      }
+    };
+
+    worker.onerror = (event) => {
+      worker.terminate();
+      reject(new Error(event.message || 'Worker error'));
+    };
+
+    worker.postMessage({ type: 'compute', resources: inputs });
+  });
+}
+
+function computeDomainsMainThread(
+  inputs: EntityComputeInput[],
+  options?: LoadDataPackageOptions,
+): void {
+  for (const input of inputs) {
+    try {
+      const domains = computeEntityDomains(input);
+      options?.onEntityDomains?.(input.entityName, domains);
+    } catch (e) {
+      options?.onError?.(
+        input.entityName,
+        e instanceof Error ? e.message : String(e),
+      );
+    }
+  }
+}

--- a/src/components/react-wrapper/index.ts
+++ b/src/components/react-wrapper/index.ts
@@ -3,4 +3,11 @@ export type { UDIVisProps } from './UDIVis';
 export type { UDIGrammar } from '../GrammarTypes';
 export type { DataSelections, ActiveDataSelection as DataSelection, RangeSelection, PointSelection } from '../DataSourcesStore';
 export { queryData } from './queryData';
-export type { QueryDataSpec, QueryDataResult } from '../ce-entry';
+export type { QueryDataSpec, QueryDataResult, QueryDataOptions } from '../ce-entry';
+export { loadDataPackage } from './loadDataPackage';
+export type { SourceSpec, LoadDataPackageOptions } from '../loadDataPackage';
+export type {
+  DataFieldDomain,
+  IntervalDomain,
+  CategoricalDomain,
+} from '../domainTypes';

--- a/src/components/react-wrapper/index.ts
+++ b/src/components/react-wrapper/index.ts
@@ -6,6 +6,7 @@ export { queryData } from './queryData';
 export type { QueryDataSpec, QueryDataResult, QueryDataOptions } from '../ce-entry';
 export { loadDataPackage } from './loadDataPackage';
 export type { SourceSpec, LoadDataPackageOptions } from '../loadDataPackage';
+export { subscribeToSelections, clearAllSelections } from './selections';
 export type {
   DataFieldDomain,
   IntervalDomain,

--- a/src/components/react-wrapper/loadDataPackage.ts
+++ b/src/components/react-wrapper/loadDataPackage.ts
@@ -1,0 +1,14 @@
+import type { SourceSpec, LoadDataPackageOptions } from '../loadDataPackage';
+
+/**
+ * Thin wrapper that lazy-loads ce-entry (same chunk as UDIVis / queryData)
+ * and delegates to the real loadDataPackage implementation. Keeps the
+ * React wrapper's static bundle small until the host actually needs it.
+ */
+export async function loadDataPackage(
+  sources: SourceSpec[],
+  options?: LoadDataPackageOptions,
+): Promise<void> {
+  const { loadDataPackage: impl } = await import('../ce-entry');
+  return impl(sources, options);
+}

--- a/src/components/react-wrapper/queryData.ts
+++ b/src/components/react-wrapper/queryData.ts
@@ -1,4 +1,8 @@
-import type { QueryDataSpec, QueryDataResult } from '../ce-entry';
+import type {
+  QueryDataSpec,
+  QueryDataResult,
+  QueryDataOptions,
+} from '../ce-entry';
 import type { DataSelections } from '../DataSourcesStore';
 
 /**
@@ -9,7 +13,8 @@ import type { DataSelections } from '../DataSourcesStore';
 export async function queryData(
   spec: QueryDataSpec,
   selections?: DataSelections,
+  options?: QueryDataOptions,
 ): Promise<QueryDataResult | null> {
   const { queryData: impl } = await import('../ce-entry');
-  return impl(spec, selections);
+  return impl(spec, selections, options);
 }

--- a/src/components/react-wrapper/selections.ts
+++ b/src/components/react-wrapper/selections.ts
@@ -1,0 +1,35 @@
+/**
+ * Thin wrappers that lazy-load ce-entry (same chunk as UDIVis / queryData
+ * / loadDataPackage) and delegate to the shared Pinia DataSourcesStore.
+ */
+
+let cachedImpl: typeof import('../ce-entry') | null = null;
+
+async function getImpl(): Promise<typeof import('../ce-entry')> {
+  if (!cachedImpl) {
+    cachedImpl = await import('../ce-entry');
+  }
+  return cachedImpl;
+}
+
+/**
+ * Fire `callback` whenever any selection in the shared DataSourcesStore
+ * changes. Returns a promise of the unsubscribe function — the underlying
+ * Pinia store loads lazily, so subscription can't be synchronous.
+ *
+ * The single-arg `() => void` convention matches Vue's `watch` stop fn
+ * and Pinia's `$subscribe` so consumers can treat it like any other
+ * store subscription.
+ */
+export async function subscribeToSelections(
+  callback: () => void,
+): Promise<() => void> {
+  const impl = await getImpl();
+  return impl.subscribeToSelections(callback);
+}
+
+/** Clear every active selection in the shared DataSourcesStore. */
+export async function clearAllSelections(): Promise<void> {
+  const impl = await getImpl();
+  impl.clearAllSelections();
+}

--- a/src/components/tsconfig.lib.json
+++ b/src/components/tsconfig.lib.json
@@ -8,5 +8,5 @@
     "moduleResolution": "nodenext",
     "baseUrl": "."
   },
-  "exclude": ["*.stories.ts", "react-wrapper/**/*", "vite.config.ce.ts", "vite.config.react.ts", "ce-entry.ts"]
+  "exclude": ["*.stories.ts", "react-wrapper/**/*", "vite.config.ce.ts", "vite.config.react.ts"]
 }

--- a/src/components/vite.config.js
+++ b/src/components/vite.config.js
@@ -38,7 +38,7 @@ export default defineConfig({
     tsConfigPaths(),
     dts({
       tsconfigPath: 'tsconfig.lib.json',
-      exclude: ['react-wrapper/**', 'ce-entry.ts', 'vite.config.ce.ts', 'vite.config.react.ts'],
+      exclude: ['react-wrapper/**', 'vite.config.ce.ts', 'vite.config.react.ts'],
     }),
   ],
 });


### PR DESCRIPTION
## Summary

Adds two headless APIs and a Web Worker to `udi-toolkit`, plus several related cleanups that let downstream consumers (udi-chat-react) drop a parallel data-loading and selection-mirroring layer. Result: each CSV is fetched and parsed exactly once; per-field domain computation runs off the main thread; selections live in one place.

### New public API surface (exported from `udi-toolkit/react` and `udi-toolkit/ce`)

- **`loadDataPackage(sources, options)`** — fetches each CSV once on the main thread, parses with Arquero, **seeds the shared Pinia `DataSourcesStore`** so subsequent `<UDIVis>` / `queryData` calls reuse the parsed table instead of re-fetching, then streams per-field domains (numeric `{min, max}` / categorical `values`) back via callbacks from a dedicated `?worker&inline` Web Worker. Falls back to main-thread compute if `new Worker(...)` throws (restrictive CSP). New worker entry ([domain-worker.ts](src/components/domain-worker.ts)) dispatches to pure compute logic in [domainCompute.ts](src/components/domainCompute.ts) so the main-thread fallback can reuse the exact same function — no duplicate implementations.

- **`subscribeToSelections(callback)`** — wraps Vue's `watch` on the store's `selectionHash` (already maintained for cache invalidation) with sync flush. Lets React (or any framework) react to brush + bound
  selections without mirroring them through a separate state store. The React wrapper returns a `Promise<() => void>` because `ce-entry` lazy-loads on first udi-toolkit call; CE consumers get a synchronous unsubscribe.

- **`clearAllSelections()`** — wipes every active selection in one operation; bumps `selectionHash` exactly once. Useful for "reset session" flows so bookkeeping entries from closed visualizations don't accumulate.

- **`QueryDataOptions`** — `queryData` now takes an options bag at position 3 (the previously-unused `sourceResolver` positional arg moves inside it, no external consumers were forwarding it). Adds
  `displayDataOnly` to skip the expensive second pipeline pass that materializes `allData` for non-rollup specs. When omitted, defaults to `true` for transformations ending in a `rollup` (where the unfiltered aggregate is rarely consumed) and `false` otherwise.

### Performance improvements inside `getDataObject`

- **Memoization cache** keyed on `(tablesVersion, selectionHash, displayDataOnly, sourceKeys, JSON.stringify(transformations))` with 64-entry LRU eviction. Brushing back to a previously-seen range serves from cache in O(1). `tablesVersion` bumps in `seedDataSource` and `initDataSource` so any data refresh invalidates cleanly.
- **`displayDataOnly` auto-default** described above — removes a footgun where callers had to opt out of the unfiltered-pass materialization for rollup specs.

### Pinia store additions ([DataSourcesStore.ts](src/components/DataSourcesStore.ts))

- `seedDataSource(name, url, table)` — install a pre-parsed ColumnTable into the cache so later `initDataSource` calls become no-ops.
- `clearAllSelections()` — wipes `dataSelections` and bumps `selectionHash`.

### Build / DX

- **Stopped excluding `ce-entry.ts` from DTS emission** ([tsconfig.lib.json](src/components/tsconfig.lib.json), [vite.config.js](src/components/vite.config.js)). `dist/ce-entry.d.ts` is
  now produced, so `QueryDataSpec` / `QueryDataResult` / `QueryDataOptions`  resolve to concrete types in consuming projects instead of degrading to  `any` via the unresolvable `'../ce-entry'` import in
  `dist/react-wrapper/index.d.ts`. This is a latent fix — those types  were always meant to be concrete; they just weren't reaching consumers.
- **`UDIVis.vue` `inheritAttrs: false`** — the template root is a  `<template v-if/v-else>` fragment, so Vue couldn't auto-inherit `class`  on the `<udi-vis>` custom-element host onto a single child and was  emitting a noisy warning on every render. The host element already gets  the class directly (CSS targeting works); silence the warning.
- **`ce.d.ts`** — hand-written DTS for the `./ce` subpath now declares `queryData`, `loadDataPackage`, `subscribeToSelections`, and `clearAllSelections` with full types.

- **README** — new subsections under "Using udi-toolkit": "Headless data query (`queryData`)", "Pre-loading data and computing domains (`loadDataPackage`)", and "Reacting to selections without re-rendering (`subscribeToSelections`)" with code examples and the `displayDataOnly` default rules.

### Compatibility

- All four smoke tests pass (Vue / CE / React / exports map; `npm test`).
- `displayDataOnly` default for rollup specs is a **soft behavior change**: callers who relied on `result.allData` being populated for rollup specs now need to pass `displayDataOnly: false` explicitly. Non-rollup specs  are unchanged (default remains `false`).
- `queryData`'s 3rd positional arg type changed from `Record<string, string>` (sourceResolver) to `QueryDataOptions`. The React wrapper never forwarded the old arg, so the public `udi-toolkit/react` surface has no break. CE consumers passing a bare sourceResolver as the 3rd positional arg would need to wrap it in `{ sourceResolver: ... }`.

### Version

May want to bump to a minor (`0.0.55` → `0.1.0` or `0.0.56`) for publish — new public API + the `queryData` 3rd-arg shape change.

## Test plan

- [x] `cd src/components && npm run build:all && npm run test` — all four smoke tests pass
- [x] Manual: in udi-chat-react (or any consumer), load a data package, brush a chart — verify each CSV is requested exactly once in DevTools Network (verify that strictmode is disabled for React - double-fetch is purposeful in that context)
- [x] Manual: throttled CPU profile during a brush drag — confirm domain compute is on a worker thread, not main
- [x] Manual: disable Worker construction (override `window.Worker` to throw) — confirm `loadDataPackage` still completes via main-thread fallback
- [x] Manual: verify no Vue console warning about "Extraneous non-props attributes (class)" when a chart card is rendered with a className
